### PR TITLE
SCMOD-3824: Moved verbose statement to be consistent with other base images

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,6 @@
                 </executions>
                 <configuration>
                     <autoPull>always</autoPull>
-                    <verbose>true</verbose>
                     <images>
                         <image>
                             <name>${dockerCafImagePrefix}opensuse-jeptalon${dockerProjectVersion}</name>
@@ -120,6 +119,7 @@
                             </build>
                         </image>
                     </images>
+                    <verbose>true</verbose>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
https://jira.autonomy.com/browse/SCMOD-3824

Not a necessary change but made to be consistent with other CAFapi base images.