### PR TITLE
SCMOD-5662: fix for talon and jep due to opensuse/leap upgrade

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -25,11 +25,11 @@ RUN zypper -n install python-devel && \
     zypper -n install python-scipy && \
     zypper -n install gcc-c++ && \
     pip install regex==2014.12.24 && \
-    pip install numpy==1.8.2 && \
+    pip install numpy==1.16.1 && \
     pip install talon==1.3.4 && \
     pip install jep==3.5.2
 
-ENV PD_PRELOAD=/usr/lib64/libpython2.7.so.1.0
+ENV LD_PRELOAD=/usr/lib64/python2.7/config/libpython2.7.so
 ENV LD_LIBRARY_PATH=/usr/lib/python2.7/site-packages/talon:/usr/lib64/python2.7/site-packages/jep
 ENV PYTHONPATH=/maven
 


### PR DESCRIPTION
## Jira

https://autjira.microfocus.com/browse/SCMOD-5662

## Build

http://sou-jenkins2.hpeswlab.net/job/CAFapi/view/Developer/job/CAFapi%7Eopensuse-jeptalon-image%7ESCMOD-5662%7ECI/

## Builds that use this image

[worker-familyhashing](http://sou-jenkins2.hpeswlab.net/job/caf/job/caf%7Eworker-familyhashing%7ESCMOD-5662%7ECI/)
[worker-markup](http://sou-jenkins2.hpeswlab.net/job/CAFDataProcessing/job/CAFDataProcessing%7Eworker-markup%7ESCMOD-5662%7ECI/)
[boilerplate-service](http://sou-jenkins2.hpeswlab.net/job/CAFDataProcessing/job/CAFDataProcessing%7Eboilerplate-service%7ESCMOD-5662%7ECI/)